### PR TITLE
Compatibility with ActiveRecord 4.x

### DIFF
--- a/ar_outer_join.gemspec
+++ b/ar_outer_join.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ArOuterJoins::VERSION
 
-  gem.add_dependency "activerecord", "~>3.2"
+  gem.add_dependency "activerecord", ">= 3.2"
   gem.add_development_dependency "rspec"
   gem.add_development_dependency "sqlite3"
   gem.add_development_dependency "pry"

--- a/lib/ar_outer_joins.rb
+++ b/lib/ar_outer_joins.rb
@@ -8,7 +8,9 @@ module ArOuterJoins
     association_joins, regular_joins = joins.partition do |join|
       join.is_a?(Hash) or join.is_a?(Array) or join.is_a?(Symbol)
     end
-    Join.new(self).apply(*association_joins).joins(*regular_joins)
+    join_set = Join.new(self).apply(*association_joins)
+    join_set = join_set.joins(*regular_joins) unless regular_joins.empty?
+    join_set
   end
 end
 

--- a/lib/ar_outer_joins/join_builder.rb
+++ b/lib/ar_outer_joins/join_builder.rb
@@ -24,7 +24,11 @@ module ArOuterJoins
           on = Arel::Nodes::On.new(table[association.foreign_key].eq(joined_table[primary_key]))
           [Arel::Nodes::OuterJoin.new(joined_table, on)]
         when :has_and_belongs_to_many
-          join_model_table = Arel::Table.new(association.options[:join_table])
+          join_model_table = if association.respond_to?(:join_table)
+              Arel::Table.new(association.join_table)
+            else
+              Arel::Table.new(association.options[:join_table])
+            end
           joined_primary_key = association.klass.primary_key
 
           on1 = Arel::Nodes::On.new(join_model_table[association.foreign_key].eq(table[primary_key]))


### PR DESCRIPTION
Fixed issue with empty arguments being passed into joins() and a change
in ActiveRecord::Reflection::AssociationReflection in 4.x.

ActiveRecord requirements upgraded to >= 3.2 in gemspec.

Maintained compatability with ActiveRecord 3.2.x

Tests pass on both 3.2.x and 4.x. Beta1
