### PR TITLE
allow for custom primary key

### DIFF
--- a/lib/ar_outer_joins/join_builder.rb
+++ b/lib/ar_outer_joins/join_builder.rb
@@ -16,7 +16,7 @@ module ArOuterJoins
         ].flatten
       else
         table = association.active_record.arel_table
-        primary_key = association.active_record.primary_key
+        primary_key = association.options[:primary_key] || association.active_record.primary_key
         joined_table = association.klass.arel_table
 
         case association.macro


### PR DESCRIPTION
This allows to use outer_joins() on a relation which specifies a custom primary key,for example: 
`has_many :product_classes, :foreign_key => :partnumber, :primary_key => :part_number`
