### PR TITLE
Defer extending ArOuterJoins onto ActiveRecord until ActiveRecord is loaded

### DIFF
--- a/lib/ar_outer_joins.rb
+++ b/lib/ar_outer_joins.rb
@@ -14,4 +14,6 @@ module ArOuterJoins
   end
 end
 
-ActiveRecord::Base.extend ArOuterJoins
+ActiveSupport.on_load :active_record do
+  extend ArOuterJoins
+end


### PR DESCRIPTION
ActiveRecord::Base is lazily loaded by Rails and we don't want to
prematurely load it, otherwise it may be loaded before initialization
runs, then any configuration set in initialization is not copied over to
ActiveRecord::Base internally.